### PR TITLE
Serve Taloon web UI from repository root

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# Taloon Chapter 3 Money Simulator
+
+This project provides a Monte Carlo simulator for Taloon's money-making phases in
+*Dragon Warrior IV* Chapter 3. The simulator models both the iron plate sales to
+the Endor armor merchant and the subsequent shop phase with Neta.
+
+## Features
+
+- Configurable starting and target gold amounts.
+- Support for multiple armor offer acceptance thresholds in a single run.
+- Phase two modelling of purchase trips, sleeping nights, and probabilistic sales.
+- Optional use of the further shop and an additional trip cutoff before sleeping.
+- Aggregated statistics and 15-second time bucket distributions for each
+  threshold.
+
+## Usage
+
+Run the CLI with Python 3.11 or newer:
+
+```bash
+python -m taloon_sim.cli [options]
+```
+
+Key options:
+
+- `--start-gold`: Gold Taloon has when the simulation begins (default 30000).
+- `--min-shop-gold`: Gold required before purchasing the shop (default 35575).
+- `--final-target`: Gold required after collecting profits from Neta (default 26000).
+- `--thresholds`: Comma-separated list of armor merchant thresholds to
+  simulate. Each run reports results for all thresholds.
+- `--runs`: Number of Monte Carlo trials per threshold (default 1000).
+- `--nights`: Nights Taloon sleeps before collecting shop profits (default 3).
+- `--use-far-shop`: Allow trips to the further shop in phase two.
+- `--additional-trip-cutoff`: If provided, allows Taloon to make one extra
+  purchase trip before sleeping whenever he has at least this amount of gold
+  remaining.
+- `--seed`: Seed for deterministic simulations.
+
+Example:
+
+```bash
+python -m taloon_sim.cli --runs 500 --thresholds 1600,1700,1800 --use-far-shop
+```
+
+### Web user interface
+
+To explore the simulator visually, launch the lightweight web server:
+
+```bash
+python -m taloon_sim.web --host 127.0.0.1 --port 8000
+```
+
+Open the reported URL in a browser to configure simulations with form inputs and
+inspect time distributions for each armor threshold. The web UI mirrors the CLI
+options and renders the 15-second bucket histograms for quick comparison.
+
+## Project Structure
+
+- `taloon_sim/constants.py`: All measured timing and cost constants.
+- `taloon_sim/phase1.py`: Logic for Taloon's iron plate sales.
+- `taloon_sim/phase2.py`: Logic for the shop phase with Neta.
+- `taloon_sim/simulation.py`: Orchestrates Monte Carlo runs and aggregates results.
+- `taloon_sim/cli.py`: Command line entry point.
+
+## License
+
+This project inherits the license distributed with the repository.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,239 @@
+const form = document.getElementById('sim-form');
+const statusEl = document.getElementById('status');
+const resultsEl = document.getElementById('results');
+const runButton = document.getElementById('run-btn');
+const resetButton = document.getElementById('reset-btn');
+const thresholdHint = document.getElementById('threshold-hint');
+
+let defaults = null;
+let constraints = null;
+let bucketSeconds = 15;
+
+async function fetchDefaults() {
+  const response = await fetch('/config');
+  if (!response.ok) {
+    throw new Error('Unable to load defaults from the server.');
+  }
+  const data = await response.json();
+  defaults = data.defaults;
+  constraints = data.constraints;
+  bucketSeconds = constraints?.time_bucket_seconds ?? bucketSeconds;
+  applyDefaults();
+}
+
+function applyDefaults() {
+  if (!defaults) {
+    return;
+  }
+  form.reset();
+  document.getElementById('start-gold').value = defaults.start_gold;
+  document.getElementById('min-shop-gold').value = defaults.min_shop_gold;
+  document.getElementById('final-target').value = defaults.final_target;
+  document.getElementById('thresholds').value = defaults.armor_thresholds.join(', ');
+  document.getElementById('nights').value = defaults.nights_to_sleep;
+  document.getElementById('runs').value = defaults.runs;
+  document.getElementById('trip-cutoff').value = defaults.additional_trip_cutoff ?? '';
+  document.getElementById('seed').value = defaults.seed ?? '';
+  document.getElementById('use-far-shop').checked = Boolean(defaults.use_far_shop);
+  if (constraints) {
+    thresholdHint.textContent = `Valid armor thresholds: ${constraints.min_threshold} – ${constraints.max_threshold} (inclusive). Time buckets are ${constraints.time_bucket_seconds}s.`;
+  }
+  clearStatus();
+  resultsEl.innerHTML = '';
+}
+
+function setStatus(message, isError = false) {
+  statusEl.textContent = message;
+  statusEl.classList.toggle('error', isError);
+}
+
+function clearStatus() {
+  statusEl.textContent = '';
+  statusEl.classList.remove('error');
+}
+
+function parseThresholds(raw) {
+  if (!raw.trim()) {
+    throw new Error('Provide at least one armor offer threshold.');
+  }
+  const min = constraints?.min_threshold ?? 0;
+  const max = constraints?.max_threshold ?? Number.MAX_SAFE_INTEGER;
+  const thresholds = raw
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .map((part) => {
+      const value = Number.parseInt(part, 10);
+      if (Number.isNaN(value)) {
+        throw new Error('Armor thresholds must be integers.');
+      }
+      if (value < min || value > max) {
+        throw new Error(`Armor thresholds must be between ${min} and ${max}.`);
+      }
+      return value;
+    });
+  if (thresholds.length === 0) {
+    throw new Error('Provide at least one armor offer threshold.');
+  }
+  return thresholds;
+}
+
+function parseOptionalNumber(value) {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+  const numeric = Number.parseInt(value, 10);
+  if (Number.isNaN(numeric)) {
+    throw new Error('Optional numeric fields must be integers if provided.');
+  }
+  return numeric;
+}
+
+function disableForm(disabled) {
+  runButton.disabled = disabled;
+  form.querySelectorAll('input').forEach((input) => {
+    input.disabled = disabled;
+  });
+  resetButton.disabled = disabled;
+}
+
+function buildHistogram(bucketCounts) {
+  const entries = bucketCounts;
+  if (!entries.length) {
+    return document.createTextNode('No simulations recorded.');
+  }
+  const maxCount = entries.reduce((max, entry) => Math.max(max, entry.count), 0);
+  const container = document.createElement('div');
+  container.className = 'histogram';
+  entries.forEach(({ label, count }) => {
+    const row = document.createElement('div');
+    row.className = 'histogram-row';
+
+    const labelSpan = document.createElement('span');
+    labelSpan.className = 'label';
+    labelSpan.textContent = label;
+    row.appendChild(labelSpan);
+
+    const bar = document.createElement('div');
+    bar.className = 'bar';
+    const rawWidth = maxCount === 0 ? 0 : (count / maxCount) * 100;
+    const width = count === 0 ? 0 : Math.max(rawWidth, 6);
+    bar.style.width = `${width}%`;
+    if (count === 0) {
+      bar.classList.add('empty');
+    }
+    bar.title = `${labelSpan.textContent}: ${count} run(s)`;
+    row.appendChild(bar);
+
+    const countSpan = document.createElement('span');
+    countSpan.className = 'value';
+    countSpan.textContent = count;
+    row.appendChild(countSpan);
+
+    container.appendChild(row);
+  });
+  return container;
+}
+
+function renderSummaries(summaries) {
+  resultsEl.innerHTML = '';
+  if (!summaries.length) {
+    const emptyState = document.createElement('p');
+    emptyState.textContent = 'No results to display yet. Run the simulation above.';
+    resultsEl.appendChild(emptyState);
+    return;
+  }
+
+  summaries.forEach((summary) => {
+    const card = document.createElement('article');
+    card.className = 'summary-card';
+
+    const title = document.createElement('h3');
+    title.textContent = `Threshold ${summary.threshold}`;
+    card.appendChild(title);
+
+    const grid = document.createElement('div');
+    grid.className = 'summary-grid';
+
+    const timeRow = document.createElement('span');
+    timeRow.innerHTML = `<strong>Average time:</strong> ${summary.average_time.toFixed(2)}s (σ ${summary.std_dev_time.toFixed(2)}s)`;
+    grid.appendChild(timeRow);
+
+    const restockRow = document.createElement('span');
+    restockRow.innerHTML = `<strong>Iron-plate restock cycles:</strong> ${summary.average_armor_restock_cycles.toFixed(2)}`;
+    grid.appendChild(restockRow);
+
+    const profitRow = document.createElement('span');
+    profitRow.innerHTML = `<strong>Shop profit cycles:</strong> ${summary.average_shop_profit_cycles.toFixed(2)}`;
+    grid.appendChild(profitRow);
+
+    const tripsRow = document.createElement('span');
+    tripsRow.innerHTML = `<strong>Shop purchase trips:</strong> ${summary.average_shop_purchase_trips.toFixed(2)}`;
+    grid.appendChild(tripsRow);
+
+    card.appendChild(grid);
+
+    const details = document.createElement('details');
+    const summaryEl = document.createElement('summary');
+    summaryEl.textContent = `Time distribution (${bucketSeconds}s buckets)`;
+    details.appendChild(summaryEl);
+    details.appendChild(buildHistogram(summary.bucket_counts));
+    card.appendChild(details);
+
+    resultsEl.appendChild(card);
+  });
+}
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  clearStatus();
+  if (!form.reportValidity()) {
+    setStatus('Please correct the highlighted fields before running the simulation.', true);
+    return;
+  }
+  disableForm(true);
+  setStatus('Running simulations…');
+
+  try {
+    const payload = {
+      start_gold: Number.parseInt(document.getElementById('start-gold').value, 10),
+      min_shop_gold: Number.parseInt(document.getElementById('min-shop-gold').value, 10),
+      final_target: Number.parseInt(document.getElementById('final-target').value, 10),
+      armor_thresholds: parseThresholds(document.getElementById('thresholds').value),
+      nights_to_sleep: Number.parseInt(document.getElementById('nights').value, 10),
+      runs: Number.parseInt(document.getElementById('runs').value, 10),
+      additional_trip_cutoff: parseOptionalNumber(document.getElementById('trip-cutoff').value),
+      seed: parseOptionalNumber(document.getElementById('seed').value),
+      use_far_shop: document.getElementById('use-far-shop').checked,
+    };
+
+    const response = await fetch('/simulate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.error || 'Simulation failed.');
+    }
+
+    renderSummaries(data.summaries ?? []);
+    setStatus(`Completed ${payload.runs} run(s) for ${payload.armor_thresholds.length} threshold option(s).`);
+  } catch (error) {
+    console.error(error);
+    setStatus(error.message || 'Simulation failed.', true);
+  } finally {
+    disableForm(false);
+  }
+});
+
+resetButton.addEventListener('click', (event) => {
+  event.preventDefault();
+  applyDefaults();
+});
+
+fetchDefaults().catch((error) => {
+  console.error(error);
+  setStatus(error.message || 'Unable to load defaults.', true);
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Taloon Chapter 3 Money Simulator</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="layout">
+      <section class="panel">
+        <h1>Taloon Chapter 3 Money Simulator</h1>
+        <p class="intro">
+          Explore different iron plate sale thresholds and shop strategies to see how they
+          affect the time needed to reach Taloon's Chapter 3 gold goals. Configure the inputs
+          below, then run the Monte Carlo simulation.
+        </p>
+        <form id="sim-form" class="form-grid">
+          <fieldset>
+            <legend>Phase breakpoints</legend>
+            <label class="field">
+              <span>Starting gold</span>
+              <input id="start-gold" name="start-gold" type="number" min="1" required />
+            </label>
+            <label class="field">
+              <span>Minimum gold before buying shop</span>
+              <input id="min-shop-gold" name="min-shop-gold" type="number" min="1" required />
+            </label>
+            <label class="field">
+              <span>Final gold target after Neta sells</span>
+              <input id="final-target" name="final-target" type="number" min="1" required />
+            </label>
+          </fieldset>
+
+          <fieldset>
+            <legend>Simulation controls</legend>
+            <label class="field">
+              <span>Armor offer thresholds (comma separated)</span>
+              <input id="thresholds" name="thresholds" type="text" required />
+            </label>
+            <label class="field">
+              <span>Nights to sleep between profit collections</span>
+              <input id="nights" name="nights" type="number" min="1" required />
+            </label>
+            <label class="field">
+              <span>Monte Carlo runs per threshold</span>
+              <input id="runs" name="runs" type="number" min="1" required />
+            </label>
+            <label class="field">
+              <span>Additional trip cutoff (optional)</span>
+              <input id="trip-cutoff" name="trip-cutoff" type="number" min="0" placeholder="Leave blank for none" />
+            </label>
+            <label class="field">
+              <span>Random seed (optional)</span>
+              <input id="seed" name="seed" type="number" placeholder="Random each run" />
+            </label>
+            <label class="checkbox">
+              <input id="use-far-shop" name="use-far-shop" type="checkbox" />
+              <span>Allow buying from the further shop</span>
+            </label>
+          </fieldset>
+
+          <div class="actions">
+            <button type="submit" id="run-btn">Run simulation</button>
+            <button type="reset" id="reset-btn" class="secondary">Reset defaults</button>
+          </div>
+        </form>
+        <p id="threshold-hint" class="hint"></p>
+        <p id="status" aria-live="polite" class="status"></p>
+      </section>
+
+      <section class="panel results" aria-live="polite">
+        <h2>Results</h2>
+        <div id="results"></div>
+      </section>
+    </main>
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,255 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.5;
+  font-size: 16px;
+  --panel-bg: rgba(255, 255, 255, 0.85);
+  --panel-border: rgba(0, 0, 0, 0.15);
+  --accent: #2f7bff;
+  --accent-contrast: #ffffff;
+  --muted: rgba(0, 0, 0, 0.6);
+  --muted-light: rgba(0, 0, 0, 0.05);
+  --danger: #b3261e;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(160deg, #071736, #193a76 40%, #0b7bc5);
+  color: #101010;
+  display: flex;
+  justify-content: center;
+}
+
+body.dark {
+  --panel-bg: rgba(16, 22, 33, 0.9);
+  --panel-border: rgba(255, 255, 255, 0.15);
+  --muted: rgba(255, 255, 255, 0.7);
+  --muted-light: rgba(255, 255, 255, 0.1);
+  color: #f5f5f5;
+}
+
+.layout {
+  display: grid;
+  gap: 1.5rem;
+  padding: 2rem;
+  width: min(1200px, 100vw);
+  box-sizing: border-box;
+}
+
+@media (min-width: 960px) {
+  .layout {
+    grid-template-columns: minmax(320px, 1fr) 2fr;
+    align-items: start;
+  }
+}
+
+.panel {
+  background-color: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 18px 45px rgba(5, 20, 45, 0.35);
+  backdrop-filter: blur(9px);
+}
+
+.results {
+  max-height: calc(100vh - 4rem);
+  overflow: auto;
+}
+
+h1,
+ h2,
+ legend {
+  margin-top: 0;
+  color: #0c2f68;
+}
+
+body.dark h1,
+body.dark h2,
+body.dark legend {
+  color: #7db3ff;
+}
+
+.intro {
+  color: var(--muted);
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+fieldset {
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+}
+
+.field input[type="number"],
+.field input[type="text"] {
+  font: inherit;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  background-color: rgba(255, 255, 255, 0.9);
+}
+
+body.dark .field input[type="number"],
+body.dark .field input[type="text"] {
+  background-color: rgba(20, 26, 40, 0.9);
+  border-color: rgba(255, 255, 255, 0.25);
+  color: inherit;
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+}
+
+.checkbox input {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+button {
+  font: inherit;
+  font-weight: 600;
+  padding: 0.6rem 1.25rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 25px rgba(5, 20, 45, 0.2);
+}
+
+button:disabled {
+  background: var(--muted-light);
+  color: var(--muted);
+  cursor: wait;
+  box-shadow: none;
+}
+
+button.secondary {
+  background: transparent;
+  color: inherit;
+  border: 1px solid var(--panel-border);
+}
+
+.status {
+  min-height: 1.5rem;
+  margin-top: 0.75rem;
+  color: var(--muted);
+}
+
+.status.error {
+  color: var(--danger);
+  font-weight: 600;
+}
+
+.results #results {
+  display: grid;
+  gap: 1rem;
+}
+
+.summary-card {
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  background: rgba(255, 255, 255, 0.85);
+  display: grid;
+  gap: 0.75rem;
+}
+
+body.dark .summary-card {
+  background: rgba(20, 26, 40, 0.9);
+}
+
+.summary-grid {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.summary-grid span {
+  display: flex;
+  justify-content: space-between;
+}
+
+.histogram {
+  display: grid;
+  gap: 0.4rem;
+  margin-top: 0.5rem;
+}
+
+.histogram-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.histogram-row .label {
+  width: 6rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+}
+
+.histogram-row .bar {
+  flex: 1;
+  height: 1rem;
+  border-radius: 8px;
+  background: linear-gradient(90deg, rgba(47, 123, 255, 0.8), rgba(15, 209, 178, 0.9));
+  position: relative;
+}
+
+.histogram-row .bar.empty {
+  min-width: 0.5rem;
+  background: repeating-linear-gradient(
+      135deg,
+      rgba(47, 123, 255, 0.35),
+      rgba(47, 123, 255, 0.35) 6px,
+      rgba(255, 255, 255, 0.3) 6px,
+      rgba(255, 255, 255, 0.3) 12px
+    );
+  border: 1px dashed rgba(47, 123, 255, 0.6);
+}
+
+.histogram-row .value {
+  min-width: 3rem;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.hint {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    color: #f5f5f5;
+  }
+}

--- a/taloon_sim/__init__.py
+++ b/taloon_sim/__init__.py
@@ -1,0 +1,5 @@
+"""Taloon Chapter 3 money-making simulator package."""
+
+from .simulation import SimulationConfig, TaloonSimulation
+
+__all__ = ["SimulationConfig", "TaloonSimulation"]

--- a/taloon_sim/cli.py
+++ b/taloon_sim/cli.py
@@ -1,0 +1,140 @@
+"""Command line entry point for the Taloon speedrun simulator."""
+
+from __future__ import annotations
+
+import argparse
+from typing import List, Sequence
+
+from . import constants as const
+from .simulation import SimulationConfig, TaloonSimulation
+
+
+def parse_thresholds(raw: str) -> List[int]:
+    values = []
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        value = int(part)
+        if value < min(const.ARMOR_BUY_PRICES) or value > max(const.ARMOR_BUY_PRICES):
+            raise argparse.ArgumentTypeError(
+                f"Armor threshold {value} outside valid range {min(const.ARMOR_BUY_PRICES)}-"
+                f"{max(const.ARMOR_BUY_PRICES)}"
+            )
+        values.append(value)
+    if not values:
+        raise argparse.ArgumentTypeError("At least one armor threshold must be provided.")
+    return values
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Simulate Taloon's Chapter 3 money-making strategy.")
+    parser.add_argument(
+        "--start-gold",
+        type=int,
+        default=const.DEFAULT_START_GOLD,
+        help="Gold on hand when the simulation begins (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--final-target",
+        type=int,
+        default=const.DEFAULT_FINAL_TARGET,
+        help="Gold required after Neta sells the inventory (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--min-shop-gold",
+        type=int,
+        default=const.DEFAULT_MIN_SHOP_GOLD,
+        help="Gold required before Taloon buys the shop (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--nights",
+        type=int,
+        default=const.DEFAULT_SLEEP_NIGHTS,
+        help="Nights Taloon sleeps before collecting shop profits (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=const.DEFAULT_SIMULATION_RUNS,
+        help="Number of Monte Carlo simulations per armor threshold (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--thresholds",
+        type=parse_thresholds,
+        default=const.DEFAULT_ARMOR_THRESHOLDS,
+        help=(
+            "Comma-separated armor offer thresholds between "
+            f"{min(const.ARMOR_BUY_PRICES)} and {max(const.ARMOR_BUY_PRICES)} "
+            "(default: %(default)s)."
+        ),
+    )
+    parser.add_argument(
+        "--use-far-shop",
+        action="store_true",
+        help="Allow purchases from the further shop as part of the plan.",
+    )
+    parser.add_argument(
+        "--additional-trip-cutoff",
+        type=int,
+        default=None,
+        help=(
+            "If provided, Taloon will immediately start another purchase trip whenever he has at least "
+            "this much gold remaining after a trip."
+        ),
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Seed for the underlying random number generator.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.final_target <= 0:
+        parser.error("Final target must be positive.")
+    if args.min_shop_gold <= const.SHOP_PURCHASE_COST:
+        parser.error("Minimum shop gold must exceed the cost of the shop purchase.")
+    if args.start_gold <= 0:
+        parser.error("Start gold must be positive.")
+    if args.nights <= 0:
+        parser.error("Number of nights must be positive.")
+    if args.runs <= 0:
+        parser.error("Number of runs must be positive.")
+    if args.additional_trip_cutoff is not None and args.additional_trip_cutoff < 0:
+        parser.error("Additional trip cutoff must be non-negative.")
+
+    config = SimulationConfig(
+        start_gold=args.start_gold,
+        final_target=args.final_target,
+        min_shop_gold=args.min_shop_gold,
+        use_far_shop=args.use_far_shop,
+        nights_to_sleep=args.nights,
+        runs=args.runs,
+        armor_thresholds=args.thresholds,
+        additional_trip_cutoff=args.additional_trip_cutoff,
+        seed=args.seed,
+    )
+
+    simulation = TaloonSimulation(config)
+    summaries = simulation.run()
+
+    for summary in summaries:
+        print(f"Threshold {summary.threshold}:")
+        print(f"  Avg time: {summary.average_time:.2f}s (std dev {summary.std_dev_time:.2f}s)")
+        print(f"  Avg iron-plate restock cycles: {summary.average_armor_restock_cycles:.2f}")
+        print(f"  Avg shop profit cycles: {summary.average_shop_profit_cycles:.2f}")
+        print(f"  Avg shop purchase trips: {summary.average_shop_purchase_trips:.2f}")
+        print(f"  Time distribution ({const.TIME_BUCKET_SECONDS}s buckets):")
+        for label, count in summary.bucket_counts.items():
+            print(f"    {label}: {count}")
+        print()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/taloon_sim/constants.py
+++ b/taloon_sim/constants.py
@@ -1,0 +1,102 @@
+"""Simulation constants for Taloon's money-making strategy."""
+
+from dataclasses import dataclass
+from typing import Tuple
+
+
+IRON_PLATE_COST: int = 1500
+IRON_PLATE_RESTOCK_COUNT: int = 7
+IRON_PLATE_RESTOCK_TIME: float = 94.0
+IRON_PLATE_WING_COST: int = 50
+
+OFFER_TIME_ACCEPT: float = 4.9
+OFFER_TIME_REJECT: float = 4.8
+
+ARMOR_BUY_PRICES = (
+    1265,
+    1289,
+    1312,
+    1335,
+    1358,
+    1382,
+    1406,
+    1429,
+    1453,
+    1476,
+    1500,
+    1523,
+    1546,
+    1570,
+    1593,
+    1617,
+    1640,
+    1664,
+    1687,
+    1710,
+    1734,
+    1757,
+    1781,
+    1804,
+    1828,
+    1851,
+    1875,
+)
+
+CRITICAL_SALE_CHANCE: float = 1.0 / 32.0
+CRITICAL_SALE_RANGE: Tuple[int, int] = (2250, 3000)
+
+DEFAULT_START_GOLD: int = 30000
+DEFAULT_FINAL_TARGET: int = 26000
+SHOP_PURCHASE_COST: int = 35000
+DEFAULT_MIN_SHOP_GOLD: int = 35575
+
+TIME_CLAIM_PROFITS_AND_TO_NEAR_SHOP: float = 20.3
+TIME_TRAVEL_EXTRA_TO_FAR_SHOP: float = 3.87
+TIME_PURCHASE_EQUIPPABLE: float = 4.1
+TIME_PURCHASE_NOT_EQUIPPABLE: float = 5.2
+TIME_RETURN_TO_NETA_FROM_NEAR: float = 7.4
+TIME_RETURN_EXTRA_FROM_FAR: float = 3.87
+TIME_GIVE_ITEM_TO_NETA: float = 5.0
+TIME_EAT_LUNCH: float = 3.0
+TIME_RETURN_FOR_SLEEP: float = 8.7
+TIME_SLEEP_ONE_NIGHT: float = 7.35
+
+INVENTORY_CAPACITY: int = 8
+
+SALE_PROBABILITY_PER_NIGHT: float = 0.75
+CRITICAL_RETURN_RANGE: Tuple[float, float] = (1.5, 2.0)
+
+DEFAULT_SIMULATION_RUNS: int = 1000
+DEFAULT_SLEEP_NIGHTS: int = 3
+
+DEFAULT_ARMOR_THRESHOLDS = (1523, 1600, 1700, 1800)
+
+
+@dataclass(frozen=True)
+class ShopItem:
+    """Description of a purchasable item for Neta's shop."""
+
+    name: str
+    cost: int
+    equippable: bool
+
+
+CLOSER_SHOP_ITEMS = (
+    ShopItem("Iron Apron", 550, True),
+    ShopItem("Iron Spear", 750, True),
+    ShopItem("Half Plate", 880, True),
+    ShopItem("Full Plate", 1250, False),
+    ShopItem("Steel Broadsword", 1600, True),
+)
+
+FURTHER_SHOP_ITEMS = (
+    ShopItem("Divine Dagger", 350, True),
+    ShopItem("Morning Star", 700, True),
+    ShopItem("Iron Shield", 1200, False),
+    ShopItem("Battle Axe", 1500, True),
+    ShopItem("Clothes H", 180, True),
+    ShopItem("Leather Armor", 650, True),
+)
+
+
+TIME_BUCKET_SECONDS: int = 15

--- a/taloon_sim/phase1.py
+++ b/taloon_sim/phase1.py
@@ -1,0 +1,73 @@
+"""Phase 1 simulation: selling iron plates to the armor merchant."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Tuple
+
+from . import constants as const
+
+
+@dataclass
+class Phase1Result:
+    """Outcome of the armor merchant selling phase."""
+
+    gold: float
+    time_seconds: float
+    restock_cycles: int
+    offers_made: int
+
+
+class Phase1Simulator:
+    """Simulate Taloon selling iron plates to reach the shop threshold."""
+
+    def __init__(self, rng: random.Random, price_threshold: int, min_shop_gold: int):
+        self._rng = rng
+        self._threshold = price_threshold
+        self._min_shop_gold = min_shop_gold
+
+    def run(self, start_gold: float) -> Phase1Result:
+        gold = float(start_gold)
+        time_spent = 0.0
+        restock_cycles = 0
+        offers = 0
+
+        plates_remaining = 0
+
+        while gold < self._min_shop_gold:
+            if plates_remaining == 0:
+                gold -= const.IRON_PLATE_COST * const.IRON_PLATE_RESTOCK_COUNT
+                gold -= const.IRON_PLATE_WING_COST
+                time_spent += const.IRON_PLATE_RESTOCK_TIME
+                plates_remaining = const.IRON_PLATE_RESTOCK_COUNT
+                restock_cycles += 1
+
+            price, _ = self._roll_offer()
+            offers += 1
+
+            if price >= self._threshold:
+                gold += price
+                time_spent += const.OFFER_TIME_ACCEPT
+                plates_remaining -= 1
+            else:
+                time_spent += const.OFFER_TIME_REJECT
+
+            if plates_remaining == 0 and gold >= self._min_shop_gold:
+                break
+
+            if plates_remaining == 0 and gold < self._min_shop_gold:
+                # Need to restock for additional plates
+                continue
+
+        return Phase1Result(gold=gold, time_seconds=time_spent, restock_cycles=restock_cycles, offers_made=offers)
+
+    def _roll_offer(self) -> Tuple[int, bool]:
+        """Generate a sale offer from the armor merchant."""
+
+        if self._rng.random() < const.CRITICAL_SALE_CHANCE:
+            low, high = const.CRITICAL_SALE_RANGE
+            return self._rng.randint(low, high), True
+
+        price = self._rng.choice(const.ARMOR_BUY_PRICES)
+        return price, False

--- a/taloon_sim/phase2.py
+++ b/taloon_sim/phase2.py
@@ -1,0 +1,189 @@
+"""Phase 2 simulation where Neta sells Taloon's inventory."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import List, Sequence
+
+from . import constants as const
+
+
+@dataclass
+class Phase2Result:
+    """Outcome from running the Neta shop phase."""
+
+    gold: float
+    time_seconds: float
+    profit_cycles: int
+    purchase_trips: int
+
+
+@dataclass
+class PurchasePlan:
+    """Items Taloon will buy during one shop trip."""
+
+    near_items: List[const.ShopItem]
+    far_items: List[const.ShopItem]
+
+    @property
+    def total_cost(self) -> int:
+        return sum(item.cost for item in self.near_items + self.far_items)
+
+    @property
+    def total_items(self) -> int:
+        return len(self.near_items) + len(self.far_items)
+
+    @property
+    def visits_far_shop(self) -> bool:
+        return bool(self.far_items)
+
+
+class Phase2Simulator:
+    """Simulates Taloon purchasing equipment for Neta to sell."""
+
+    def __init__(
+        self,
+        rng: random.Random,
+        nights_to_sleep: int,
+        final_target: int,
+        use_far_shop: bool,
+        additional_trip_cutoff: int | None,
+    ) -> None:
+        self._rng = rng
+        self._nights_to_sleep = nights_to_sleep
+        self._final_target = final_target
+        self._use_far_shop = use_far_shop
+        self._additional_trip_cutoff = additional_trip_cutoff
+        candidate_items = list(const.CLOSER_SHOP_ITEMS)
+        if use_far_shop:
+            candidate_items.extend(const.FURTHER_SHOP_ITEMS)
+        self._cheapest_item_cost = min(item.cost for item in candidate_items)
+
+    def run(self, start_gold: float) -> Phase2Result:
+        gold = float(start_gold) - const.SHOP_PURCHASE_COST
+        if gold < 0:
+            raise ValueError("Insufficient gold to purchase the shop.")
+
+        time_spent = 0.0
+        profit_cycles = 0
+        total_trips = 0
+        pending_profits = 0.0
+        neta_inventory: List[int] = []
+
+        while gold < self._final_target or pending_profits > 0 or neta_inventory:
+            if pending_profits:
+                gold += pending_profits
+                pending_profits = 0.0
+
+            if gold >= self._final_target and not neta_inventory:
+                break
+
+            profit_cycles += 1
+
+            trips_this_cycle = 0
+            purchased_any = False
+
+            while True:
+                plan = self._plan_purchases(gold)
+                if plan.total_items == 0:
+                    break
+
+                if trips_this_cycle > 0 and self._additional_trip_cutoff is not None:
+                    if gold < self._additional_trip_cutoff or trips_this_cycle >= 2:
+                        break
+                if trips_this_cycle > 0 and self._additional_trip_cutoff is None:
+                    break
+
+                trips_this_cycle += 1
+                total_trips += 1
+                purchased_any = True
+
+                time_spent += const.TIME_CLAIM_PROFITS_AND_TO_NEAR_SHOP
+
+                # Purchase near shop items
+                for item in plan.near_items:
+                    time_spent += const.TIME_PURCHASE_EQUIPPABLE if item.equippable else const.TIME_PURCHASE_NOT_EQUIPPABLE
+
+                if plan.visits_far_shop:
+                    time_spent += const.TIME_TRAVEL_EXTRA_TO_FAR_SHOP
+                    for item in plan.far_items:
+                        time_spent += const.TIME_PURCHASE_EQUIPPABLE if item.equippable else const.TIME_PURCHASE_NOT_EQUIPPABLE
+
+                time_spent += const.TIME_RETURN_TO_NETA_FROM_NEAR
+                if plan.visits_far_shop:
+                    time_spent += const.TIME_RETURN_EXTRA_FROM_FAR
+
+                time_spent += const.TIME_EAT_LUNCH
+                time_spent += plan.total_items * const.TIME_GIVE_ITEM_TO_NETA
+
+                gold -= plan.total_cost
+                for item in plan.near_items:
+                    neta_inventory.append(item.cost)
+                for item in plan.far_items:
+                    neta_inventory.append(item.cost)
+
+            if not purchased_any and not neta_inventory:
+                # Nothing to sell and not enough gold: exit to avoid infinite loop
+                break
+
+            # Move to the sleeping portion of the cycle
+            time_spent += const.TIME_RETURN_FOR_SLEEP
+            time_spent += self._nights_to_sleep * const.TIME_SLEEP_ONE_NIGHT
+
+            # Simulate sales over the sleeping nights
+            for _ in range(self._nights_to_sleep):
+                remaining_inventory: List[int] = []
+                for cost in neta_inventory:
+                    if self._rng.random() < const.SALE_PROBABILITY_PER_NIGHT:
+                        multiplier = self._rng.uniform(*const.CRITICAL_RETURN_RANGE)
+                        sale_value = round(cost * multiplier)
+                        pending_profits += sale_value
+                    else:
+                        remaining_inventory.append(cost)
+                neta_inventory = remaining_inventory
+
+        # Collect any final pending profits if needed
+        if pending_profits:
+            gold += pending_profits
+            pending_profits = 0.0
+
+        return Phase2Result(
+            gold=gold,
+            time_seconds=time_spent,
+            profit_cycles=profit_cycles,
+            purchase_trips=total_trips,
+        )
+
+    def _plan_purchases(self, gold: float) -> PurchasePlan:
+        """Choose items to purchase based on available gold and capacity."""
+
+        near_items: List[const.ShopItem] = []
+        far_items: List[const.ShopItem] = []
+
+        capacity_remaining = const.INVENTORY_CAPACITY
+        available_gold = int(gold)
+
+        candidates: List[tuple[str, const.ShopItem]] = [
+            ("near", item) for item in const.CLOSER_SHOP_ITEMS
+        ]
+        if self._use_far_shop:
+            candidates.extend(("far", item) for item in const.FURTHER_SHOP_ITEMS)
+
+        candidates.sort(key=lambda pair: pair[1].cost, reverse=True)
+
+        for shop_name, item in candidates:
+            if capacity_remaining == 0:
+                break
+            max_copies = min(available_gold // item.cost, capacity_remaining)
+            for _ in range(max_copies):
+                if shop_name == "near":
+                    near_items.append(item)
+                else:
+                    far_items.append(item)
+                available_gold -= item.cost
+                capacity_remaining -= 1
+                if capacity_remaining == 0:
+                    break
+
+        return PurchasePlan(near_items=near_items, far_items=far_items)

--- a/taloon_sim/simulation.py
+++ b/taloon_sim/simulation.py
@@ -1,0 +1,130 @@
+"""Core simulation orchestration for Taloon's strategy."""
+
+from __future__ import annotations
+
+import random
+import statistics
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from . import constants as const
+from .phase1 import Phase1Simulator
+from .phase2 import Phase2Simulator
+
+
+@dataclass
+class SimulationConfig:
+    """Configuration values for a complete simulation run."""
+
+    start_gold: int = const.DEFAULT_START_GOLD
+    final_target: int = const.DEFAULT_FINAL_TARGET
+    min_shop_gold: int = const.DEFAULT_MIN_SHOP_GOLD
+    use_far_shop: bool = False
+    nights_to_sleep: int = const.DEFAULT_SLEEP_NIGHTS
+    runs: int = const.DEFAULT_SIMULATION_RUNS
+    armor_thresholds: Sequence[int] = field(default_factory=lambda: const.DEFAULT_ARMOR_THRESHOLDS)
+    additional_trip_cutoff: Optional[int] = None
+    seed: Optional[int] = None
+
+
+@dataclass
+class SimulationRunResult:
+    """Record the results for a single Monte Carlo run."""
+
+    total_time: float
+    armor_restock_cycles: int
+    shop_profit_cycles: int
+    shop_purchase_trips: int
+
+
+@dataclass
+class ThresholdSummary:
+    """Aggregated statistics for a single armor price threshold."""
+
+    threshold: int
+    average_time: float
+    std_dev_time: float
+    average_armor_restock_cycles: float
+    average_shop_profit_cycles: float
+    average_shop_purchase_trips: float
+    bucket_counts: Dict[str, int]
+
+
+class TaloonSimulation:
+    """Run the full Taloon simulation for multiple thresholds."""
+
+    def __init__(self, config: SimulationConfig) -> None:
+        self._config = config
+
+    def run(self) -> List[ThresholdSummary]:
+        summaries = []
+        for threshold in self._config.armor_thresholds:
+            results = self._run_threshold(threshold)
+            summaries.append(self._summarize(threshold, results))
+        return summaries
+
+    def _run_threshold(self, threshold: int) -> List[SimulationRunResult]:
+        results: List[SimulationRunResult] = []
+        for run_index in range(self._config.runs):
+            seed_offset = hash((self._config.seed, threshold, run_index)) & 0xFFFFFFFF
+            rng = random.Random(seed_offset)
+            phase1 = Phase1Simulator(rng, threshold, self._config.min_shop_gold)
+            phase1_result = phase1.run(self._config.start_gold)
+
+            phase2 = Phase2Simulator(
+                rng,
+                nights_to_sleep=self._config.nights_to_sleep,
+                final_target=self._config.final_target,
+                use_far_shop=self._config.use_far_shop,
+                additional_trip_cutoff=self._config.additional_trip_cutoff,
+            )
+            phase2_result = phase2.run(phase1_result.gold)
+
+            total_time = phase1_result.time_seconds + phase2_result.time_seconds
+
+            results.append(
+                SimulationRunResult(
+                    total_time=total_time,
+                    armor_restock_cycles=phase1_result.restock_cycles,
+                    shop_profit_cycles=phase2_result.profit_cycles,
+                    shop_purchase_trips=phase2_result.purchase_trips,
+                )
+            )
+        return results
+
+    def _summarize(self, threshold: int, results: Iterable[SimulationRunResult]) -> ThresholdSummary:
+        results = list(results)
+        times = [result.total_time for result in results]
+        armor_restock_cycles = [result.armor_restock_cycles for result in results]
+        shop_profit_cycles = [result.shop_profit_cycles for result in results]
+        shop_purchase_trips = [result.shop_purchase_trips for result in results]
+
+        bucket_counts: Dict[str, int] = {}
+        for total_time in times:
+            bucket_label = self._bucket_label(total_time)
+            bucket_counts[bucket_label] = bucket_counts.get(bucket_label, 0) + 1
+
+        return ThresholdSummary(
+            threshold=threshold,
+            average_time=statistics.mean(times) if times else 0.0,
+            std_dev_time=statistics.pstdev(times) if len(times) > 1 else 0.0,
+            average_armor_restock_cycles=
+                statistics.mean(armor_restock_cycles) if armor_restock_cycles else 0.0,
+            average_shop_profit_cycles=
+                statistics.mean(shop_profit_cycles) if shop_profit_cycles else 0.0,
+            average_shop_purchase_trips=
+                statistics.mean(shop_purchase_trips) if shop_purchase_trips else 0.0,
+            bucket_counts=dict(sorted(bucket_counts.items(), key=lambda item: self._bucket_key(item[0]))),
+        )
+
+    @staticmethod
+    def _bucket_label(total_time: float) -> str:
+        bucket_index = int(total_time // const.TIME_BUCKET_SECONDS)
+        start = bucket_index * const.TIME_BUCKET_SECONDS
+        end = start + const.TIME_BUCKET_SECONDS
+        return f"{start:>4}-{end:>4}s"
+
+    @staticmethod
+    def _bucket_key(label: str) -> int:
+        start_str = label.split("-", 1)[0].strip()
+        return int(start_str[:-1]) if start_str.endswith("s") else int(start_str)

--- a/taloon_sim/web.py
+++ b/taloon_sim/web.py
@@ -1,0 +1,201 @@
+"""Minimal web server and UI for exploring Taloon simulation results."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+from http import HTTPStatus
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence
+
+from . import constants as const
+from .simulation import SimulationConfig, TaloonSimulation
+
+# Serve the static assets from the repository root so GitHub Pages can host the
+# interface directly without additional configuration.
+WEB_DIR = Path(__file__).resolve().parents[1]
+
+
+class TaloonRequestHandler(SimpleHTTPRequestHandler):
+    """Serve the static UI and expose an API endpoint for simulations."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, directory=str(WEB_DIR), **kwargs)
+
+    def do_GET(self) -> None:  # noqa: N802 - required by SimpleHTTPRequestHandler
+        if self.path == "/config":
+            self._handle_config()
+            return
+
+        if self.path in {"", "/"}:
+            self.path = "/index.html"
+
+        super().do_GET()
+
+    def do_POST(self) -> None:  # noqa: N802 - required by SimpleHTTPRequestHandler
+        if self.path == "/simulate":
+            self._handle_simulate()
+            return
+
+        self.send_error(HTTPStatus.NOT_FOUND, "Unsupported endpoint")
+
+    # ------------------------------------------------------------------
+    # Endpoint handlers
+    # ------------------------------------------------------------------
+    def _handle_config(self) -> None:
+        payload = {
+            "defaults": {
+                "start_gold": const.DEFAULT_START_GOLD,
+                "final_target": const.DEFAULT_FINAL_TARGET,
+                "min_shop_gold": const.DEFAULT_MIN_SHOP_GOLD,
+                "use_far_shop": False,
+                "nights_to_sleep": const.DEFAULT_SLEEP_NIGHTS,
+                "runs": const.DEFAULT_SIMULATION_RUNS,
+                "armor_thresholds": list(const.DEFAULT_ARMOR_THRESHOLDS),
+                "additional_trip_cutoff": None,
+                "seed": None,
+            },
+            "constraints": {
+                "min_threshold": min(const.ARMOR_BUY_PRICES),
+                "max_threshold": max(const.ARMOR_BUY_PRICES),
+                "time_bucket_seconds": const.TIME_BUCKET_SECONDS,
+            },
+        }
+        self._send_json(HTTPStatus.OK, payload)
+
+    def _handle_simulate(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        try:
+            raw_body = self.rfile.read(length).decode("utf-8") if length else "{}"
+            payload = json.loads(raw_body)
+            config = build_config_from_payload(payload)
+            simulation = TaloonSimulation(config)
+            summaries = simulation.run()
+            response = {
+                "summaries": [
+                    {
+                        **asdict(summary),
+                        "bucket_counts": [
+                            {"label": label, "count": count}
+                            for label, count in summary.bucket_counts.items()
+                        ],
+                    }
+                    for summary in summaries
+                ]
+            }
+            self._send_json(HTTPStatus.OK, response)
+        except ValueError as exc:  # validation issue
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+        except json.JSONDecodeError:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": "Invalid JSON payload."})
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _send_json(self, status: HTTPStatus, payload: Dict[str, Any]) -> None:
+        data = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+def build_config_from_payload(payload: Dict[str, Any]) -> SimulationConfig:
+    """Validate incoming payload data and build a SimulationConfig."""
+
+    def require_positive(value: Any, field: str) -> int:
+        try:
+            numeric = int(value)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError(f"{field} must be an integer.") from exc
+        if numeric <= 0:
+            raise ValueError(f"{field} must be positive.")
+        return numeric
+
+    start_gold = require_positive(payload.get("start_gold", const.DEFAULT_START_GOLD), "Start gold")
+    final_target = require_positive(payload.get("final_target", const.DEFAULT_FINAL_TARGET), "Final target")
+    min_shop_gold = require_positive(payload.get("min_shop_gold", const.DEFAULT_MIN_SHOP_GOLD), "Minimum shop gold")
+    nights_to_sleep = require_positive(payload.get("nights_to_sleep", const.DEFAULT_SLEEP_NIGHTS), "Nights to sleep")
+    runs = require_positive(payload.get("runs", const.DEFAULT_SIMULATION_RUNS), "Runs")
+
+    thresholds_raw = payload.get("armor_thresholds", list(const.DEFAULT_ARMOR_THRESHOLDS))
+    if not isinstance(thresholds_raw, Sequence) or isinstance(thresholds_raw, (str, bytes)):
+        raise ValueError("Armor thresholds must be provided as a list of integers.")
+    thresholds: list[int] = []
+    min_threshold = min(const.ARMOR_BUY_PRICES)
+    max_threshold = max(const.ARMOR_BUY_PRICES)
+    for value in thresholds_raw:
+        try:
+            threshold = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Armor thresholds must contain only integers.") from exc
+        if threshold < min_threshold or threshold > max_threshold:
+            raise ValueError(
+                f"Armor thresholds must fall between {min_threshold} and {max_threshold}."
+            )
+        thresholds.append(threshold)
+    if not thresholds:
+        raise ValueError("At least one armor threshold must be provided.")
+
+    additional_trip_cutoff = payload.get("additional_trip_cutoff")
+    if additional_trip_cutoff is not None:
+        try:
+            additional_trip_cutoff = int(additional_trip_cutoff)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Additional trip cutoff must be an integer or null.") from exc
+        if additional_trip_cutoff < 0:
+            raise ValueError("Additional trip cutoff must be non-negative.")
+
+    if min_shop_gold <= const.SHOP_PURCHASE_COST:
+        raise ValueError("Minimum shop gold must exceed the cost of purchasing the shop.")
+
+    seed_value = payload.get("seed")
+    seed: Optional[int]
+    if seed_value in (None, ""):
+        seed = None
+    else:
+        try:
+            seed = int(seed_value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Seed must be an integer or null.") from exc
+
+    use_far_shop = bool(payload.get("use_far_shop", False))
+
+    return SimulationConfig(
+        start_gold=start_gold,
+        final_target=final_target,
+        min_shop_gold=min_shop_gold,
+        use_far_shop=use_far_shop,
+        nights_to_sleep=nights_to_sleep,
+        runs=runs,
+        armor_thresholds=thresholds,
+        additional_trip_cutoff=additional_trip_cutoff,
+        seed=seed,
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Run the Taloon simulator web UI server.")
+    parser.add_argument("--host", default="127.0.0.1", help="Host interface to bind (default: %(default)s).")
+    parser.add_argument("--port", type=int, default=8000, help="Port to listen on (default: %(default)s).")
+    args = parser.parse_args(argv)
+
+    if not WEB_DIR.exists():
+        raise RuntimeError(f"Web assets directory missing: {WEB_DIR}")
+
+    server_address = (args.host, args.port)
+    httpd = HTTPServer(server_address, TaloonRequestHandler)
+    print(f"Serving Taloon simulator web UI on http://{args.host}:{args.port}")
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:  # pragma: no cover - manual stop
+        print("\nShutting down...")
+    finally:
+        httpd.server_close()
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()


### PR DESCRIPTION
## Summary
- relocate the static web UI assets (index.html, app.js, styles.css) to the repository root so GitHub Pages can serve the simulator without extra configuration
- update the Python web server to serve static files from the new root location

## Testing
- python -m taloon_sim.cli --runs 2 --thresholds 1600,1700 --seed 1
- python -m taloon_sim.web --host 127.0.0.1 --port 8765 (manually interrupted with Ctrl+C)


------
https://chatgpt.com/codex/tasks/task_e_68e3f05036a883329b418b8de96a248d