### PR TITLE
Update results summary to highlight average completion times

### DIFF
--- a/app.js
+++ b/app.js
@@ -259,41 +259,40 @@ function renderSummaries(summaries) {
     return;
   }
 
-  const overallFastest = summaries.reduce((best, summary) => {
-    if (!best) {
-      return summary;
-    }
-    if (summary.fastest_time < best.fastest_time) {
-      return summary;
-    }
-    return best;
-  }, null);
+  const topAverageSummaries = [...summaries]
+    .sort((a, b) => a.average_time - b.average_time)
+    .slice(0, 3);
 
-  if (overallFastest) {
+  if (topAverageSummaries.length) {
     const highlight = document.createElement('div');
     highlight.className = 'results-overview';
 
     const heading = document.createElement('h3');
-    heading.textContent = 'Overall highlight';
+    heading.textContent = 'Top thresholds by average completion time';
     highlight.appendChild(heading);
 
-    const fastestRow = document.createElement('p');
-    const fastestLabel = document.createElement('strong');
-    fastestLabel.textContent = 'Fastest completion:';
-    fastestRow.appendChild(fastestLabel);
+    const list = document.createElement('ol');
+    list.className = 'results-ranking';
 
-    const fastestDetails = document.createElement('span');
-    fastestDetails.textContent = ` ${formatDuration(overallFastest.fastest_time)} (threshold ${overallFastest.threshold}). `;
-    fastestRow.appendChild(fastestDetails);
+    topAverageSummaries.forEach((summary) => {
+      const listItem = document.createElement('li');
 
-    const averageDetails = document.createElement('span');
-    averageDetails.textContent = `Average run: ${formatDuration(overallFastest.average_time)} (σ ${formatDuration(
-      overallFastest.std_dev_time
-    )}).`;
-    fastestRow.appendChild(averageDetails);
-    fastestRow.title =
-      'Fastest single run across all thresholds along with the average and standard deviation for that threshold.';
-    highlight.appendChild(fastestRow);
+      const thresholdLabel = document.createElement('strong');
+      thresholdLabel.textContent = `Threshold ${summary.threshold}`;
+      listItem.appendChild(thresholdLabel);
+
+      const stats = document.createElement('span');
+      stats.textContent = `Average ${formatDuration(summary.average_time)} (σ ${formatDuration(
+        summary.std_dev_time
+      )})`;
+      listItem.appendChild(stats);
+
+      listItem.title =
+        'Thresholds ranked by quickest average completion time, including their standard deviation across all runs.';
+      list.appendChild(listItem);
+    });
+
+    highlight.appendChild(list);
 
     resultsEl.appendChild(highlight);
   }

--- a/styles.css
+++ b/styles.css
@@ -220,6 +220,29 @@ body.dark .summary-card {
   color: var(--results-text);
 }
 
+.results-overview .results-ranking {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.results-overview .results-ranking li {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  align-items: baseline;
+  color: var(--results-text);
+}
+
+.results-overview .results-ranking li strong {
+  color: var(--results-emphasis);
+}
+
+.results-overview .results-ranking li span {
+  color: var(--results-muted);
+}
+
 .summary-grid {
   display: grid;
   gap: 0.35rem;


### PR DESCRIPTION
## Summary
- rank the results overview by lowest average completion time instead of fastest single run
- display the top three thresholds with emphasis on the threshold number and supplementary average/deviation details
- style the ranked list in the overview for clearer readability

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e412c559b88332b7257a0946127e19