### PR TITLE
Add purchase strategy selection and abacus options

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ the Endor armor merchant and the subsequent shop phase with Neta.
 - Phase two modelling of purchase trips, sleeping nights, and probabilistic sales.
 - Optional use of the further shop and an additional trip cutoff before sleeping.
 - Sleep-night overrides that shorten rest when few items were delivered.
+- Configurable purchase-planning strategies, including an abacus-aware option with customizable thresholds.
 - Aggregated statistics and histogram buckets for each threshold.
 
 ## Usage
@@ -35,7 +36,8 @@ node cli.js --runs 500 --thresholds 1600,1700,1800 --use-far-shop
 ```
 
 Use `--help` to see the full list of options, including overrides for starting
-gold, target gold, sleep nights, optional reduced-sleep thresholds, the
+gold, target gold, sleep nights, optional reduced-sleep thresholds, purchase
+strategy (greedy, max-spend, or abacus-aware with custom thresholds), the
 additional trip cutoff, RNG seed, and histogram bucket sizing.
 
 You can also install the executable locally:

--- a/config.json
+++ b/config.json
@@ -10,7 +10,10 @@
     "runs": 1000,
     "additional_trip_cutoff": null,
     "seed": null,
-    "use_far_shop": false
+    "use_far_shop": false,
+    "purchase_strategy": "greedy",
+    "abacus_count_threshold": null,
+    "abacus_price_cutoff": null
   },
   "constraints": {
     "min_threshold": 1265,

--- a/defaults.js
+++ b/defaults.js
@@ -1,4 +1,8 @@
-import { CONSTANTS, DEFAULT_TIME_BUCKET_SECONDS } from './simulation.js';
+import {
+  CONSTANTS,
+  DEFAULT_TIME_BUCKET_SECONDS,
+  DEFAULT_PURCHASE_STRATEGY,
+} from './simulation.js';
 
 export const DEFAULT_FORM_CONFIG = {
   defaults: {
@@ -13,6 +17,9 @@ export const DEFAULT_FORM_CONFIG = {
     additional_trip_cutoff: null,
     seed: null,
     use_far_shop: false,
+    purchase_strategy: DEFAULT_PURCHASE_STRATEGY,
+    abacus_count_threshold: null,
+    abacus_price_cutoff: null,
   },
   constraints: {
     min_threshold: Math.min(...CONSTANTS.ARMOR_BUY_PRICES),

--- a/index.html
+++ b/index.html
@@ -88,6 +88,40 @@
               <input id="use-far-shop" name="use-far-shop" type="checkbox" />
               <span>Allow buying from the further shop</span>
             </label>
+            <label class="field" title="Choose how Taloon plans his shopping trips when stocking Neta.">
+              <span>Purchase strategy</span>
+              <select id="purchase-strategy" name="purchase-strategy">
+                <option value="greedy">Greedy (buy priciest items first)</option>
+                <option value="max-spend">Maximize total spend</option>
+                <option value="abacus-greedy">Abacus-aware greedy</option>
+              </select>
+            </label>
+            <label
+              class="field"
+              title="When using the abacus-aware strategy, require at least this many Abacus of Virtue purchases before skipping cheaper items."
+            >
+              <span>Abacus count threshold (abacus strategy)</span>
+              <input
+                id="abacus-count-threshold"
+                name="abacus-count-threshold"
+                type="number"
+                min="0"
+                placeholder="Enter count when using abacus strategy"
+              />
+            </label>
+            <label
+              class="field"
+              title="When using the abacus-aware strategy, ignore shop items cheaper than this gold amount once the abacus count condition is met."
+            >
+              <span>Abacus price cutoff (abacus strategy)</span>
+              <input
+                id="abacus-price-cutoff"
+                name="abacus-price-cutoff"
+                type="number"
+                min="0"
+                placeholder="Enter gold cutoff when using abacus strategy"
+              />
+            </label>
           </fieldset>
         </form>
         <p id="threshold-hint" class="hint"></p>


### PR DESCRIPTION
## Summary
- add UI controls and defaults for selecting purchase strategies and configuring abacus thresholds
- implement greedy, max-spend, and abacus-aware planning logic with a new abacus item
- extend the CLI and documentation to describe the new strategy options

## Testing
- node cli.js --runs 1 --thresholds 1600 --purchase-strategy greedy --abacus-count-threshold null --abacus-price-cutoff null
- node cli.js --runs 1 --thresholds 1600 --purchase-strategy abacus-greedy --abacus-count-threshold 3 --abacus-price-cutoff 550


------
https://chatgpt.com/codex/tasks/task_e_68e4276821b48332ad47f28cb9497f0b