### PR TITLE
Restore per-trip abacus cutoff behavior

### DIFF
--- a/simulation.js
+++ b/simulation.js
@@ -235,22 +235,14 @@ function planGreedyPurchase({
         ? normalizedAbacus.cutoff
         : null;
 
-    if (priceCutoff != null && candidate.item.cost <= priceCutoff) {
+    if (priceCutoff != null && !isAbacusItem && candidate.item.cost <= priceCutoff) {
       continue;
     }
 
-    let maxCopies = Math.min(
+    const maxCopies = Math.min(
       Math.floor(availableGold / candidate.item.cost),
       capacity - plan.totalItems
     );
-
-    if (hasAbacusThreshold && isAbacusItem) {
-      const remainingAbaci = normalizedAbacus.threshold - abaciInPlan;
-      if (remainingAbaci <= 0) {
-        continue;
-      }
-      maxCopies = Math.min(maxCopies, remainingAbaci);
-    }
 
     if (maxCopies <= 0) {
       continue;


### PR DESCRIPTION
## Summary
- limit the abacus-aware greedy threshold to items bought in the current trip only
- stop purchases at or below the configured cutoff once the abacus threshold is satisfied

## Testing
- `node cli.js --thresholds 1600 --runs 10 --seed 123 --purchase-strategy abacus-greedy --abacus-count-threshold 3 --abacus-price-cutoff 550 --use-far-shop`


------
https://chatgpt.com/codex/tasks/task_e_68e43625eb008332858303039f41e193