### PR TITLE
Stop phase two when Taloon has enough gold

### DIFF
--- a/simulation.js
+++ b/simulation.js
@@ -429,6 +429,7 @@ function runPhase2(rng, config) {
     purchaseStrategy,
     abacusCountThreshold,
     abacusPriceCutoff,
+    cycleObserver = null,
   } = config;
 
   let gold = Number(config.startGold) - CONSTANTS.SHOP_PURCHASE_COST;
@@ -443,18 +444,25 @@ function runPhase2(rng, config) {
   let netaInventory = [];
 
   while (gold < finalTarget || pendingProfits > 0 || netaInventory.length) {
+    const cycleStartGold = gold;
+    const cycleStartPending = pendingProfits;
+    const cycleStartInventory = netaInventory.length;
+    const cycleStartTime = timeSpent;
+
     if (pendingProfits > 0) {
       gold += pendingProfits;
       pendingProfits = 0;
     }
 
-    if (gold >= finalTarget && netaInventory.length === 0) {
+    if (gold >= finalTarget) {
       break;
     }
 
     let tripsThisCycle = 0;
     let purchasedAny = false;
     let itemsAddedThisCycle = 0;
+
+    const nightSummaries = [];
 
     while (true) {
       const plan = planPurchases({
@@ -540,8 +548,14 @@ function runPhase2(rng, config) {
 
     timeSpent += nightsThisCycle * CONSTANTS.TIME_SLEEP_ONE_NIGHT;
 
+    const inventoryBeforeSleep = netaInventory.length;
+    let totalSoldThisCycle = 0;
+    let profitsThisCycle = 0;
+
     for (let night = 0; night < nightsThisCycle; night += 1) {
       const remainingInventory = [];
+      let soldThisNight = 0;
+      let profitThisNight = 0;
       for (const cost of netaInventory) {
         if (rng.random() < CONSTANTS.SALE_PROBABILITY_PER_NIGHT) {
           const multiplier = rng.uniform(
@@ -550,11 +564,44 @@ function runPhase2(rng, config) {
           );
           const saleValue = Math.round(cost * multiplier);
           pendingProfits += saleValue;
+          soldThisNight += 1;
+          profitThisNight += saleValue;
         } else {
           remainingInventory.push(cost);
         }
       }
       netaInventory = remainingInventory;
+      totalSoldThisCycle += soldThisNight;
+      profitsThisCycle += profitThisNight;
+      if (cycleObserver) {
+        nightSummaries.push({
+          night: night + 1,
+          soldCount: soldThisNight,
+          profitsGenerated: profitThisNight,
+          inventoryRemaining: netaInventory.length,
+        });
+      }
+    }
+
+    if (cycleObserver) {
+      cycleObserver({
+        cycleIndex: netaCycles,
+        startGold: cycleStartGold,
+        goldAfterPurchases: gold,
+        pendingProfitsAtStart: cycleStartPending,
+        pendingProfitsAfterSleep: pendingProfits,
+        itemsAddedThisCycle,
+        nightsScheduled: nightsToSleep,
+        nightsSlept: nightsThisCycle,
+        inventoryAtStart: cycleStartInventory,
+        inventoryBeforeSleep,
+        inventoryAfterSleep: netaInventory.length,
+        itemsSoldThisCycle: totalSoldThisCycle,
+        profitsGeneratedThisCycle: profitsThisCycle,
+        tripsThisCycle,
+        timeSpentThisCycle: timeSpent - cycleStartTime,
+        nightSummaries,
+      });
     }
   }
 
@@ -691,4 +738,61 @@ export function runSimulation(config) {
   }
 
   return { seed: baseSeed, summaries };
+}
+
+export function runSingleSimulation(config, options = {}) {
+  const thresholds = Array.from(config.armor_thresholds || []);
+  if (thresholds.length === 0) {
+    throw new Error('runSingleSimulation requires at least one armor threshold.');
+  }
+
+  const thresholdIndex =
+    typeof options.thresholdIndex === 'number' && options.thresholdIndex >= 0
+      ? Math.floor(options.thresholdIndex)
+      : 0;
+  if (thresholdIndex >= thresholds.length) {
+    throw new Error('thresholdIndex is out of range for provided thresholds.');
+  }
+
+  const threshold = thresholds[thresholdIndex];
+  const baseSeed = normalizeSeed(config.seed);
+  const runIndex =
+    typeof options.runIndex === 'number' && options.runIndex >= 0
+      ? Math.floor(options.runIndex)
+      : 0;
+  const seed = hashSeedComponents(baseSeed, threshold, runIndex);
+  const rng = createRng(seed);
+
+  const phase1Result = runPhase1(
+    rng,
+    threshold,
+    config.min_shop_gold,
+    config.start_gold
+  );
+
+  const cycleLogs = [];
+  const phase2Result = runPhase2(rng, {
+    startGold: phase1Result.gold,
+    nightsToSleep: config.nights_to_sleep,
+    finalTarget: config.final_target,
+    useFarShop: config.use_far_shop,
+    additionalTripCutoff: config.additional_trip_cutoff,
+    twoSleepItemThreshold: config.two_sleep_item_threshold,
+    oneSleepItemThreshold: config.one_sleep_item_threshold,
+    purchaseStrategy: config.purchase_strategy,
+    abacusCountThreshold: config.abacus_count_threshold,
+    abacusPriceCutoff: config.abacus_price_cutoff,
+    cycleObserver: options.captureCycles ? (cycle) => cycleLogs.push(cycle) : null,
+  });
+
+  return {
+    threshold,
+    baseSeed,
+    runIndex,
+    seed,
+    totalTime: phase1Result.timeSeconds + phase2Result.timeSeconds,
+    phase1: phase1Result,
+    phase2: phase2Result,
+    cycleLogs,
+  };
 }

--- a/sleep_analysis.js
+++ b/sleep_analysis.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import { runSimulation, formatDuration } from './simulation.js';
+
+const baseConfig = {
+  runs: 20000,
+  start_gold: 35575,
+  min_shop_gold: 35575,
+  final_target: 26000,
+  armor_thresholds: [1570],
+  nights_to_sleep: 3,
+  two_sleep_item_threshold: null,
+  one_sleep_item_threshold: null,
+  use_far_shop: false,
+  additional_trip_cutoff: null,
+  seed: null,
+  time_bucket_seconds: 30,
+  purchase_strategy: 'greedy',
+  abacus_count_threshold: null,
+  abacus_price_cutoff: null,
+};
+
+const scenarios = [
+  {
+    name: 'Always sleep 3 nights',
+    overrides: {},
+  },
+  {
+    name: 'Sleep 2 nights for <=7 items',
+    overrides: {
+      two_sleep_item_threshold: 7,
+    },
+  },
+  {
+    name: 'Always sleep 2 nights',
+    overrides: {
+      nights_to_sleep: 2,
+    },
+  },
+];
+
+for (const scenario of scenarios) {
+  const config = { ...baseConfig, ...scenario.overrides };
+  const { summaries } = runSimulation(config);
+  const summary = summaries[0];
+
+  console.log(`Scenario: ${scenario.name}`);
+  console.log(`  Avg time: ${summary.average_time.toFixed(2)} seconds (${formatDuration(summary.average_time)})`);
+  console.log(
+    `  Avg Neta cycles: ${summary.average_shop_cycles.toFixed(2)} (trips ${summary.average_shop_trips.toFixed(2)})`
+  );
+  console.log(
+    `  Avg trips per cycle: ${summary.average_shop_trips_per_cycle.toFixed(3)}`
+  );
+  console.log('');
+}

--- a/sleep_tail_analysis.js
+++ b/sleep_tail_analysis.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+import { runSingleSimulation, formatDuration } from './simulation.js';
+
+const runs = 100000;
+
+const baseConfig = {
+  runs,
+  start_gold: 35575,
+  min_shop_gold: 35575,
+  final_target: 26000,
+  armor_thresholds: [1570],
+  nights_to_sleep: 3,
+  two_sleep_item_threshold: null,
+  one_sleep_item_threshold: null,
+  use_far_shop: false,
+  additional_trip_cutoff: null,
+  seed: null,
+  time_bucket_seconds: 30,
+  purchase_strategy: 'greedy',
+  abacus_count_threshold: null,
+  abacus_price_cutoff: null,
+};
+
+const scenarios = [
+  {
+    name: 'Always sleep 3 nights',
+    overrides: {},
+  },
+  {
+    name: 'Sleep 2 nights for <=7 items',
+    overrides: {
+      two_sleep_item_threshold: 7,
+    },
+  },
+  {
+    name: 'Always sleep 2 nights',
+    overrides: {
+      nights_to_sleep: 2,
+    },
+  },
+];
+
+function percentile(values, target) {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil((target / 100) * sorted.length) - 1)
+  );
+  return sorted[index];
+}
+
+for (const scenario of scenarios) {
+  const config = { ...baseConfig, ...scenario.overrides };
+  const times = [];
+  let maxRun = null;
+
+  for (let runIndex = 0; runIndex < runs; runIndex += 1) {
+    const result = runSingleSimulation(config, { runIndex });
+    times.push(result.totalTime);
+    if (!maxRun || result.totalTime > maxRun.totalTime) {
+      maxRun = { runIndex, totalTime: result.totalTime };
+    }
+  }
+
+  const avg = times.reduce((sum, value) => sum + value, 0) / times.length;
+  const p90 = percentile(times, 90);
+  const p99 = percentile(times, 99);
+  const maxResult = runSingleSimulation(config, {
+    runIndex: maxRun.runIndex,
+    captureCycles: true,
+  });
+
+  console.log(`Scenario: ${scenario.name}`);
+  console.log(
+    `  Avg: ${avg.toFixed(2)}s (${formatDuration(avg)}) | P90: ${formatDuration(p90)} | P99: ${formatDuration(p99)} | Max: ${formatDuration(maxRun.totalTime)}`
+  );
+  console.log(`  Longest run index: ${maxRun.runIndex}`);
+  console.log('  Cycle breakdown for longest run:');
+  for (const cycle of maxResult.cycleLogs) {
+    const {
+      cycleIndex,
+      itemsAddedThisCycle,
+      nightsSlept,
+      inventoryBeforeSleep,
+      inventoryAfterSleep,
+      itemsSoldThisCycle,
+      timeSpentThisCycle,
+      nightSummaries,
+    } = cycle;
+    const unsold = inventoryAfterSleep;
+    console.log(
+      `    Cycle ${cycleIndex}: +${itemsAddedThisCycle} items, slept ${nightsSlept}, sold ${itemsSoldThisCycle}, unsold ${unsold}, time ${timeSpentThisCycle.toFixed(
+        2
+      )}s`
+    );
+    for (const night of nightSummaries) {
+      console.log(
+        `      Night ${night.night}: sold ${night.soldCount}, remaining ${night.inventoryRemaining}`
+      );
+    }
+  }
+  console.log('');
+}


### PR DESCRIPTION
## Summary
- allow phase two to exit as soon as Taloon holds the final target amount of gold regardless of remaining Neta inventory

## Testing
- node sleep_tail_analysis.js

------
https://chatgpt.com/codex/tasks/task_e_68e447e59a748332985ae21203e986da