### PR TITLE
Ensure sleep overrides apply when skipping purchases

### DIFF
--- a/simulation.js
+++ b/simulation.js
@@ -532,18 +532,16 @@ function runPhase2(rng, config) {
     timeSpent += CONSTANTS.TIME_RETURN_FOR_SLEEP;
     netaCycles += 1;
     let nightsThisCycle = nightsToSleep;
-    if (itemsAddedThisCycle > 0) {
-      if (
-        oneSleepItemThreshold != null &&
-        itemsAddedThisCycle <= oneSleepItemThreshold
-      ) {
-        nightsThisCycle = Math.min(nightsThisCycle, 1);
-      } else if (
-        twoSleepItemThreshold != null &&
-        itemsAddedThisCycle <= twoSleepItemThreshold
-      ) {
-        nightsThisCycle = Math.min(nightsThisCycle, 2);
-      }
+    if (
+      oneSleepItemThreshold != null &&
+      itemsAddedThisCycle <= oneSleepItemThreshold
+    ) {
+      nightsThisCycle = Math.min(nightsThisCycle, 1);
+    } else if (
+      twoSleepItemThreshold != null &&
+      itemsAddedThisCycle <= twoSleepItemThreshold
+    ) {
+      nightsThisCycle = Math.min(nightsThisCycle, 2);
     }
 
     timeSpent += nightsThisCycle * CONSTANTS.TIME_SLEEP_ONE_NIGHT;


### PR DESCRIPTION
## Summary
- allow sleep-night overrides to trigger even when a cycle adds no new items
- keep two-sleep override logic aligned with fixed sleep configurations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e44cf0a900833298593eb2e25dc8fd